### PR TITLE
Include `windows-rs` documentation in the generated docs

### DIFF
--- a/crates/bindings/build.bat
+++ b/crates/bindings/build.bat
@@ -1,3 +1,3 @@
 time /t
-cargo doc --no-deps --target-dir ..\..\docs
+cargo doc --no-deps -p windows -p bindings --target-dir ..\..\docs
 time /t

--- a/readme.md
+++ b/readme.md
@@ -12,4 +12,6 @@ The build cannot be automated with GitHub Actions as it takes around 30 minutes 
 
 It can be manually generated as follows:
 
-`C:\git\windows-docs-rs\crates\bindings>cargo doc --no-deps --target-dir ..\..\docs`
+```console
+C:\git\windows-docs-rs\crates\bindings> cargo doc --no-deps -p windows -p bindings --target-dir ..\..\docs
+```


### PR DESCRIPTION
Following missing documentation in https://github.com/microsoft/windows-rs/issues/765.

---

None of the predefined types like `Result`, `HRESULT` or any other type in `windows-rs` are clickable links to the respective documentation. The `--extern-html-root-url` feature is still unstable but could otherwise be used to link to external documentation like `docs.rs/windows`.

EDIT: However, that will not make `windows::` types searchable from `windows-docs-rs` since the types are still only linked externally. They are not part of the search index (afaik).

Note that by explicitly specifying what crates to document, both the `windows` and `bindings` crate have to be listed.